### PR TITLE
Support for nextcord

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">Cog Watch</h1>
     
 <div align="center">
-  <strong><i>Automatic hot-reloading for your discord.py command files.</i></strong>
+  <strong><i>Automatic hot-reloading for your discord.py / nextcord command files.</i></strong>
   <br>
   <br>
   
@@ -15,7 +15,7 @@
 </div>
 <br>
 
-`cogwatch` is a utility that you can plug into your `discord.py` bot that will watch your command
+`cogwatch` is a utility that you can plug into your `discord.py` or `nextcord` bot that will watch your command
 files directory *(cogs)* and automatically reload them as you modify or move them around in
 real-time. No more reloading your bot / command yourself every time you edit an embed just to make
 sure it looks perfect!

--- a/cogwatch/cogwatch.py
+++ b/cogwatch/cogwatch.py
@@ -5,10 +5,12 @@ import sys
 from functools import wraps
 from pathlib import Path
 
-from discord.ext import commands
+try:
+    from discord.ext import commands
+except ImportError:
+    from nextcord.ext import commands
 from watchfiles import Change, awatch
 
-print(__name__)
 logger = logging.getLogger('cogwatch')
 logger.addHandler(logging.NullHandler())
 # prevents log events bubbling up to the parent and duplicating output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = 'cogwatch'
 version = '3.0.1'
-description = 'Automatic hot-reloading for your discord.py command files.'
+description = 'Automatic hot-reloading for your discord.py / nextcord command files.'
 authors = ['Rob Wagner <rob@sombia.com>']
 license = 'MIT'
 readme = 'README.md'


### PR DESCRIPTION
Try to import nextcord if discord fails. As nextcord requires discord.py to be uninstalled, it will use the except statement.

I'm using nextcord for the UI syntax, and saw your library, thanks for this project!